### PR TITLE
Add ExecStart and restart settings to boot manager service

### DIFF
--- a/emos-boot-manager.service
+++ b/emos-boot-manager.service
@@ -1,3 +1,9 @@
 [Unit]
 Description=EMOS Boot Mode Manager
-...
+
+[Service]
+ExecStart=/home/spindle/emosconfiguratorv2/emos_boot_manager.sh
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- define the startup script for `emos-boot-manager.service`
- restart service when it exits
- allow enabling under `multi-user.target`

## Testing
- `python3 -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862d2e093a88324bc276ffd7d254740