### PR TITLE
Refactor FastAPI entrypoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,8 @@
 from fastapi import FastAPI
+
 app = FastAPI()
-@app.get('/')
-def read_root(): return {'msg': 'ok'}
+
+@app.get("/")
+async def read_root():
+    """Return a simple health check response."""
+    return {"msg": "ok"}


### PR DESCRIPTION
## Summary
- format `app/main.py` with blank lines and async endpoint
- add docstring describing `/` endpoint

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6862cec76df08324aa57b408799b45c3