### PR TITLE
Fix extraneous HTML line in index

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -21,5 +21,3 @@
 </body>
 </html>
 
-<html><body><h1>EMOS Configurator</h1></body></html>
-


### PR DESCRIPTION
## Summary
- clean up the template by removing a stray HTML line

## Testing
- `python -m py_compile $(find . -name '*.py')` *(fails: '(' was never closed)*

------
https://chatgpt.com/codex/tasks/task_e_6862e8229c288324ae1feb6e502f6145