### PR TITLE
Fix install script missing network interfaces directory

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,7 +8,8 @@ sudo apt update
 sudo apt install -y dnsmasq hostapd python3-pip
 
 # Maak directories indien nodig
-mkdir -p /etc/emos
+sudo mkdir -p /etc/emos
+sudo mkdir -p /etc/network/interfaces.d
 sudo cp config/dnsmasq.conf /etc/dnsmasq.conf
 sudo cp config/hostapd.conf /etc/hostapd/hostapd.conf
 sudo cp config/wlan0_static.conf /etc/network/interfaces.d/wlan0_static.conf


### PR DESCRIPTION
## Summary
- ensure `/etc/network/interfaces.d` is created in the install script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68639c243f0c8324bfaf5fda9702ba4b