### PR TITLE
Use python -m uvicorn in service

### DIFF
--- a/emos-configurator.service
+++ b/emos-configurator.service
@@ -3,7 +3,7 @@ Description=EMOS Configurator Web Interface
 After=network.target
 
 [Service]
-ExecStart=/home/spindle/emosconfiguratorv2/.venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000
+ExecStart=/usr/bin/python3 -m uvicorn app.main:app --host 0.0.0.0 --port 8000
 WorkingDirectory=/home/spindle/emosconfiguratorv2
 Restart=always
 User=spindle


### PR DESCRIPTION
## Summary
- invoke uvicorn via `python3 -m` in the systemd unit for better compatibility on Raspberry Pi

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6863aa5246dc8324b8c68071f06406e4