### PR TITLE
Enable switching to business mode from UI

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -8,6 +8,9 @@
     <form method="post" action="/arp_scan">
         <button type="submit">ARP Scan</button>
     </form>
+    <form method="post" action="/business">
+        <button type="submit">Switch to Business Mode</button>
+    </form>
 
     {% if scan_results %}
     <h2>ARP Scan Results</h2>

--- a/userguide.md
+++ b/userguide.md
@@ -8,3 +8,4 @@
    - Choose codec (MJPEG / H264)
    - Set multicast port
    - Save per camera
+5. Klik op "Switch to Business Mode" om het apparaat naar bedrijfsmodus te zetten


### PR DESCRIPTION
## Summary
- add helper to start business mode and begin hotspot
- expose `/business` endpoint to trigger the switch
- include new button in index template
- mention button in user guide

## Testing
- `python -m py_compile app/main.py app/network.py app/occ_wrapper.py`
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6863b338d6488324a5cba2385a92136e