### PR TITLE
Add OCC build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,13 @@ Follow these steps to set up the configurator:
    sudo ./scripts/install.sh
    ```
 
-    The script installs required packages, disables `NetworkManager` and
-    `dhcpcd` (both enabled by default on Raspberry Pi OS Bookworm), configures
-    `systemd-networkd` so that `wlan0` uses the static address `192.168.10.1`,
-    and sets up `hostapd` and `dnsmasq` so that the hotspot works right after
-    reboot. The system is marked for business mode on the next reboot.
+   The script installs required packages, disables `NetworkManager` and
+   `dhcpcd` (both enabled by default on Raspberry Pi OS Bookworm), configures
+   `systemd-networkd` so that `wlan0` uses the static address `192.168.10.1`,
+   and sets up `hostapd` and `dnsmasq` so that the hotspot works right after
+   reboot. It also builds the [OCC](https://github.com/Codemonkey1973/OCC)
+   utility and installs it to `/usr/bin/occ`. The system is marked for business
+   mode on the next reboot.
 
 2. **Business mode** – after the reboot, connect to Wi‑Fi network `Spindle_EMOS_Config` and open [http://192.168.10.1:8000](http://192.168.10.1:8000). The ethernet interface is now used only to configure EMOS cameras and for ARP scans.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,7 +5,17 @@ echo "[INFO] Starting EMOS Configurator installation..."
 
 # Update en dependencies
 sudo apt update
-sudo apt install -y dnsmasq hostapd python3-pip
+sudo apt install -y dnsmasq hostapd python3-pip git build-essential
+
+# Install OCC binary if missing
+if [ ! -f /usr/bin/occ ]; then
+    echo "[INFO] Installing OCC (Open Camera Configurator)..."
+    TMPDIR=$(mktemp -d)
+    git clone --depth 1 https://github.com/Codemonkey1973/OCC "$TMPDIR/occ"
+    make -C "$TMPDIR/occ"
+    sudo install -m 0755 "$TMPDIR/occ/occ" /usr/bin/occ
+    rm -rf "$TMPDIR"
+fi
 
 # Disable NetworkManager and dhcpcd which conflict with systemd-networkd on Bookworm
 sudo systemctl disable --now NetworkManager || true


### PR DESCRIPTION
## Summary
- build OCC from source if missing and install
- mention OCC binary installation in README

## Testing
- `bash -n scripts/install.sh`
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_6863d60ca32c8324a312acd90bbb1f31