### PR TITLE
Add eth0 mode toggle

### DIFF
--- a/app/network.py
+++ b/app/network.py
@@ -83,3 +83,28 @@ def get_subnet(interface: str = "eth0") -> str:
             if len(parts) >= 2:
                 return parts[1]
     return ""
+
+
+def set_eth0_static(ip: str = "192.168.40.240/24") -> None:
+    """Configure ``eth0`` with a static IP address."""
+    subprocess.run(["sudo", "ip", "addr", "flush", "dev", "eth0"], check=False)
+    subprocess.run(["sudo", "ip", "addr", "add", ip, "dev", "eth0"], check=False)
+    subprocess.run(["sudo", "ip", "link", "set", "eth0", "up"], check=False)
+
+
+def set_eth0_dhcp() -> None:
+    """Bring ``eth0`` up and obtain an address via DHCP."""
+    subprocess.run(["sudo", "ip", "addr", "flush", "dev", "eth0"], check=False)
+    subprocess.run(["sudo", "ip", "link", "set", "eth0", "up"], check=False)
+    subprocess.run(["sudo", "dhclient", "-1", "eth0"], check=False)
+
+
+def eth0_is_static(ip: str = "192.168.40.240/24") -> bool:
+    """Return ``True`` if ``eth0`` has the specified static address."""
+    try:
+        output = subprocess.check_output(
+            ["ip", "-4", "addr", "show", "dev", "eth0"], text=True
+        )
+    except subprocess.CalledProcessError:
+        return False
+    return ip in output

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -29,8 +29,8 @@
     <form method="get" action="/">
         <button type="submit">Refresh</button>
     </form>
-    <form method="post" action="/business">
-        <button type="submit">Switch to Business Mode</button>
+    <form method="post" action="{% if eth0_static %}/dhcp{% else %}/business{% endif %}">
+        <button type="submit">{% if eth0_static %}DHCP Mode{% else %}Switch to Business Mode{% endif %}</button>
     </form>
 
     {% if scan_results %}

--- a/userguide.md
+++ b/userguide.md
@@ -11,4 +11,6 @@
 5. Use the **Discover** form to find connected cameras. Toggle the slider to
    switch between scanning and sniffing. With sniffing enabled, the subnet of
    `eth0` can be copied automatically.
-6. Klik op "Switch to Business Mode" om het apparaat naar bedrijfsmodus te zetten
+6. Klik op "Switch to Business Mode" om het apparaat naar bedrijfsmodus te zetten.
+   Het ethernetinterface krijgt dan het statische adres `192.168.40.240/24`.
+   Druk daarna op "DHCP Mode" om weer een adres via DHCP op te halen.


### PR DESCRIPTION
## Summary
- add helpers to configure eth0 statically or via DHCP
- toggle the mode from the main page
- update user guide for new button behaviour

## Testing
- `python -m py_compile app/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e9e488e08324bed45c0a0456af6b