### PR TITLE
Add separate sniffer page

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Visit `http://192.168.10.1:8000` to access the web interface. Each camera can be
 assigned a codec and multicast port via the form and the settings are saved
 through the FastAPI backend.
 
-Use the **Discover** form on the web page to find connected cameras. A slider
-allows switching between active ARP scanning and a passive sniffer mode. In
-sniffer mode the application runs ``tcpdump`` for one minute and lists all EMOS
-cameras it sees, showing both MAC and IP address regardless of the subnet.
+Open the **Discover** page to sniff for cameras. The sniffer runs ``tcpdump``
+for one minute and shows every EMOS camera it sees, including the MAC and IP
+address. The detected subnet can then be applied to ``eth0`` with a single
+click so the cameras can be configured via OCC.
 
 An alternative is to passively sniff the ethernet interface for broadcast or
 multicast traffic. The cameras regularly send out packets such as mDNS, SSDP or

--- a/app/network.py
+++ b/app/network.py
@@ -120,3 +120,24 @@ def eth0_is_static(ip: str = "192.168.40.240/24") -> bool:
     except subprocess.CalledProcessError:
         return False
     return ip in output
+
+
+def subnet_from_ip(ip: str) -> str:
+    """Return a /24 subnet in CIDR notation derived from *ip*."""
+    parts = ip.split(".")
+    if len(parts) != 4:
+        return ""
+    return ".".join(parts[:3] + ["0"]) + "/24"
+
+
+def set_eth0_subnet(subnet: str) -> None:
+    """Configure ``eth0`` for the supplied ``subnet``."""
+    try:
+        network, prefix = subnet.split("/")
+    except ValueError:
+        return
+    parts = network.split(".")
+    if len(parts) != 4:
+        return
+    ip = ".".join(parts[:3] + ["240"]) + f"/{prefix}"
+    set_eth0_static(ip)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,27 +2,10 @@
 <html>
 <head>
     <title>EMOS Configurator</title>
-    <style>
-    .switch {position: relative; display: inline-block; width: 50px; height: 24px;}
-    .switch input {display:none;}
-    .slider {position:absolute; cursor:pointer; top:0; left:0; right:0; bottom:0; background-color:#ccc; transition:.4s; border-radius:24px;}
-    .slider:before {position:absolute; content:""; height:18px; width:18px; left:3px; bottom:3px; background-color:white; transition:.4s; border-radius:50%;}
-    input:checked + .slider {background-color:#2196F3;}
-    input:checked + .slider:before {transform: translateX(26px);}
-    #sniffOptions {margin-top: 8px; display: none;}
-    </style>
 </head>
 <body>
     <h1>EMOS Configurator</h1>
-    <form id="discoverForm" method="post" action="/discover">
-        <label class="switch">
-            <input type="checkbox" id="modeToggle" name="mode" value="sniff" {% if mode == 'sniff' %}checked{% endif %}>
-            <span class="slider"></span>
-        </label>
-        <span id="modeLabel">{% if mode == 'sniff' %}Sniff{% else %}Scan{% endif %}</span>
-        <div id="sniffOptions" style="display: none;"></div>
-        <button type="submit">Ontdekken</button>
-    </form>
+    <p><a href="/sniffer">Discover cameras</a></p>
     <form method="get" action="/">
         <button type="submit">Refresh</button>
     </form>
@@ -30,21 +13,7 @@
         <button type="submit">{% if eth0_static %}DHCP Mode{% else %}Switch to Business Mode{% endif %}</button>
     </form>
 
-    {% if scan_results %}
-    <h2>Resultaten</h2>
-    <ul>
-        {% for res in scan_results %}
-        <li>
-            {% if res.mac %}
-            {{ res.mac }} - {{ res.ip }}
-            {% else %}
-            {{ res.ip }}
-            {% endif %}
-        </li>
-        {% endfor %}
-    </ul>
-    {% endif %}
-{% if cameras %}
+    {% if cameras %}
     {% for camera_id, setting in cameras.items() %}
     <h2>Camera {{ camera_id }}</h2>
     <form method="post" action="/settings/{{ camera_id }}">
@@ -60,26 +29,6 @@
     {% endfor %}
     {% else %}
     <p>No cameras detected.</p>
-{% endif %}
-<script>
-const toggle = document.getElementById('modeToggle');
-const sniffOpts = document.getElementById('sniffOptions');
-const label = document.getElementById('modeLabel');
-
-function updateView() {
-    if (toggle.checked) {
-        label.textContent = 'Sniff';
-        sniffOpts.style.display = 'block';
-    } else {
-        label.textContent = 'Scan';
-        sniffOpts.style.display = 'none';
-    }
-}
-
-toggle.addEventListener('change', updateView);
-updateView();
-
-</script>
+    {% endif %}
 </body>
 </html>
-

--- a/app/templates/sniffer.html
+++ b/app/templates/sniffer.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>EMOS Sniffer</title>
+</head>
+<body>
+    <h1>Discover EMOS Cameras</h1>
+    <form method="post" action="/sniffer">
+        <button type="submit">Sniff</button>
+    </form>
+    <p><a href="/">Back to configuration</a></p>
+    {% if results %}
+    <h2>Results</h2>
+    <ul>
+        {% for res in results %}
+        <li>{{ res.mac }} - {{ res.ip }}</li>
+        {% endfor %}
+    </ul>
+    {% if subnet %}
+    <form method="post" action="/apply_subnet">
+        <input type="hidden" name="subnet" value="{{ subnet }}" />
+        <button type="submit">Use subnet {{ subnet }}</button>
+    </form>
+    {% endif %}
+    {% endif %}
+</body>
+</html>

--- a/userguide.md
+++ b/userguide.md
@@ -8,9 +8,9 @@
    - Choose codec (MJPEG / H264)
    - Set multicast port
    - Save per camera
-5. Use the **Discover** form to find connected cameras. Toggle the slider to
-   switch between scanning and sniffing. In sniff mode ``tcpdump`` runs for one
-   minute and lists the MAC and IP address of each EMOS camera.
+5. Open the **Discover** page to sniff for EMOS cameras. ``tcpdump`` runs for
+   one minute and lists the MAC and IP address of each camera. Apply the detected
+   subnet to ``eth0`` and return to the configuration page to adjust settings.
 6. Klik op "Switch to Business Mode" om het apparaat naar bedrijfsmodus te zetten.
    Het ethernetinterface krijgt dan het statische adres `192.168.40.240/24`.
    Druk daarna op "DHCP Mode" om weer een adres via DHCP op te halen.


### PR DESCRIPTION
## Summary
- split sniffer UI into separate page
- support applying discovered subnet to eth0
- document updated workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f56a662083249959259678a00008