### PR TITLE
Implement selectable sniffer duration with progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Visit `http://192.168.10.1:8000` to access the web interface. Each camera can be
 assigned a codec and multicast port via the form and the settings are saved
 through the FastAPI backend.
 
-Open the **Discover** page to sniff for cameras. The sniffer runs ``tcpdump``
-for one minute and shows every EMOS camera it sees, including the MAC and IP
-address. The detected subnet can then be applied to ``eth0`` with a single
-click so the cameras can be configured via OCC.
+Open the **Discover** page to sniff for cameras. The sniffer can run ``tcpdump``
+for 5, 10 or 30 seconds and shows every EMOS camera it sees, including the MAC
+and IP address. The detected subnet can then be applied to ``eth0`` with a
+single click so the cameras can be configured via OCC.
 
 An alternative is to passively sniff the ethernet interface for broadcast or
 multicast traffic. The cameras regularly send out packets such as mDNS, SSDP or

--- a/app/main.py
+++ b/app/main.py
@@ -91,10 +91,13 @@ async def sniffer_page(request: Request):
     )
 
 
-@app.post("/sniffer", response_class=HTMLResponse)
-async def run_sniffer(request: Request):
-    results = network.sniff_emos_cameras(interface="eth0")
+@app.post("/sniffer")
+async def run_sniffer(request: Request, duration: int = Form(30)):
+    """Run the sniffer for ``duration`` seconds and return results."""
+    results = network.sniff_emos_cameras(interface="eth0", timeout=duration)
     subnet = network.subnet_from_ip(results[0]["ip"]) if results else ""
+    if request.headers.get("accept") == "application/json":
+        return {"results": results, "subnet": subnet}
     return templates.TemplateResponse(
         "sniffer.html",
         {"request": request, "results": results, "subnet": subnet},

--- a/app/templates/sniffer.html
+++ b/app/templates/sniffer.html
@@ -5,23 +5,69 @@
 </head>
 <body>
     <h1>Discover EMOS Cameras</h1>
-    <form method="post" action="/sniffer">
+    <form id="snifferForm" method="post" action="/sniffer">
+        <label for="duration">Duration:</label>
+        <select id="duration" name="duration">
+            <option value="5">5s</option>
+            <option value="10">10s</option>
+            <option value="30" selected>30s</option>
+        </select>
         <button type="submit">Sniff</button>
     </form>
+    <div id="progressContainer" style="display:none;width:100%;background:#ccc;margin-top:8px;">
+        <div id="progressBar" style="width:0;height:20px;background:#4CAF50;"></div>
+    </div>
     <p><a href="/">Back to configuration</a></p>
-    {% if results %}
     <h2>Results</h2>
-    <ul>
+    <ul id="results">
         {% for res in results %}
         <li>{{ res.mac }} - {{ res.ip }}</li>
         {% endfor %}
     </ul>
-    {% if subnet %}
-    <form method="post" action="/apply_subnet">
+    <form id="subnetForm" method="post" action="/apply_subnet" {% if not subnet %}style="display:none"{% endif %}>
         <input type="hidden" name="subnet" value="{{ subnet }}" />
-        <button type="submit">Use subnet {{ subnet }}</button>
+        <button type="submit">Use subnet <span id="subnetLabel">{{ subnet }}</span></button>
     </form>
-    {% endif %}
-    {% endif %}
+
+    <script>
+    const form = document.getElementById('snifferForm');
+    const progress = document.getElementById('progressBar');
+    const container = document.getElementById('progressContainer');
+    form.addEventListener('submit', (ev) => {
+        ev.preventDefault();
+        const duration = parseInt(document.getElementById('duration').value, 10);
+        progress.style.width = '0%';
+        container.style.display = 'block';
+        const start = Date.now();
+        const timer = setInterval(() => {
+            const pct = Math.min(100, ((Date.now() - start) / 1000) / duration * 100);
+            progress.style.width = pct + '%';
+            if (pct >= 100) clearInterval(timer);
+        }, 100);
+        const data = new FormData(form);
+        fetch('/sniffer', {method: 'POST', body: data, headers: {'Accept': 'application/json'}})
+            .then(r => r.json())
+            .then(data => {
+                clearInterval(timer);
+                progress.style.width = '100%';
+                container.style.display = 'none';
+                const list = document.getElementById('results');
+                list.innerHTML = '';
+                data.results.forEach(r => {
+                    const li = document.createElement('li');
+                    li.textContent = r.mac + ' - ' + r.ip;
+                    list.appendChild(li);
+                });
+                const subForm = document.getElementById('subnetForm');
+                if (data.subnet) {
+                    subForm.style.display = 'block';
+                    subForm.querySelector('input[name="subnet"]').value = data.subnet;
+                    document.getElementById('subnetLabel').textContent = data.subnet;
+                } else {
+                    subForm.style.display = 'none';
+                }
+            });
+    });
+    </script>
 </body>
 </html>

--- a/userguide.md
+++ b/userguide.md
@@ -8,9 +8,9 @@
    - Choose codec (MJPEG / H264)
    - Set multicast port
    - Save per camera
-5. Open the **Discover** page to sniff for EMOS cameras. ``tcpdump`` runs for
-   one minute and lists the MAC and IP address of each camera. Apply the detected
-   subnet to ``eth0`` and return to the configuration page to adjust settings.
+5. Open the **Discover** page to sniff for EMOS cameras. ``tcpdump`` can run for
+   5, 10 or 30 seconds and lists the MAC and IP address of each camera. Apply the
+   detected subnet to ``eth0`` and return to the configuration page to adjust settings.
 6. Klik op "Switch to Business Mode" om het apparaat naar bedrijfsmodus te zetten.
    Het ethernetinterface krijgt dan het statische adres `192.168.40.240/24`.
    Druk daarna op "DHCP Mode" om weer een adres via DHCP op te halen.


### PR DESCRIPTION
## Summary
- allow choosing sniffer duration (5s, 10s or 30s)
- show a progress bar during sniffing
- return JSON results for Ajax requests
- document the configurable sniffer duration

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6863f928b67483249add0b06d0bc4a66