### PR TITLE
Add tcpdump to install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,7 +5,7 @@ echo "[INFO] Starting EMOS Configurator installation..."
 
 # Update en dependencies
 sudo apt update
-sudo apt install -y dnsmasq hostapd python3-pip git build-essential \
+sudo apt install -y dnsmasq hostapd tcpdump python3-pip git build-essential \
     gcc-aarch64-linux-gnu
 
 # Install OCC binary if missing


### PR DESCRIPTION
## Summary
- install tcpdump alongside other packages

## Testing
- `bash -n scripts/install.sh`
- `shellcheck scripts/install.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f9bd09f08324b9ad9eefdfcb7ce4